### PR TITLE
feat!: add initial royalties and "free" minting/linkdrops for owner

### DIFF
--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -23,5 +23,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - uses: actions/cache@v2
+        with:
+          path: '/home/runner/work/tenk/tenk/.near-credentials/workspaces'
+          key: ${{ matrix.platform }}${{ workspaces.os }}-${{ hashFiles('$HOME/.near-credentials/workspaces/testnet/*') }}
       - name: Run tests
         run: yarn && yarn test:linkdrop

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -1,0 +1,27 @@
+name: Linkdrop
+on: push
+jobs:
+  tests:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        node-version: ['14']
+        toolchain: [stable]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: "${{ matrix.toolchain }} with rustfmt, and wasm32"
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          target: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v1
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+      - name: install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Run tests
+        run: yarn && yarn test:linkdrop

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -26,6 +26,6 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: '/home/runner/work/tenk/tenk/.near-credentials/workspaces'
-          key: ${{ matrix.platform }}${{ workspaces.os }}-${{ hashFiles('$HOME/.near-credentials/workspaces/testnet/*') }}
+          key: ${{ matrix.platform }}-${{ hashFiles('$HOME/.near-credentials/workspaces/testnet/*') }}
       - name: Run tests
         run: yarn && yarn test:linkdrop

--- a/__test__/linkdrop.ava.ts
+++ b/__test__/linkdrop.ava.ts
@@ -23,10 +23,13 @@ import {
   create_account_and_claim,
   deploy,
   linkdropCost,
+  sleep,
 } from "./util";
 
 const base_cost = NEAR.parse("1 N");
 const min_cost = NEAR.parse("0.01 N");
+
+
 
 if (Workspace.networkIsTestnet()) {
   const runner = Workspace.init(
@@ -43,6 +46,7 @@ if (Workspace.networkIsTestnet()) {
           await readFile(`${__dirname}/contracts/testnet.wasm`)
         );
       }
+      await sleep(2000);
       return { tenk };
     }
   );

--- a/__test__/linkdrop.ava.ts
+++ b/__test__/linkdrop.ava.ts
@@ -46,7 +46,6 @@ if (Workspace.networkIsTestnet()) {
           await readFile(`${__dirname}/contracts/testnet.wasm`)
         );
       }
-      await sleep(2000);
       return { tenk };
     }
   );
@@ -55,6 +54,7 @@ if (Workspace.networkIsTestnet()) {
     "Use `claim` to send to existing account",
     async (t, { root, tenk }) => {
       const alice = await root.createAccount("alice");
+      await sleep(2000);
       t.log(NEAR.from(await tenk.view("token_storage_cost")).toHuman());
 
       // Create temporary keys for access key on linkdrop
@@ -86,6 +86,7 @@ if (Workspace.networkIsTestnet()) {
     "Use `claim` to send to existing account with normal account",
     async (t, { root, tenk }) => {
       const alice = await root.createAccount("alice");
+      await sleep(2000);
       t.log(NEAR.from(await tenk.view("token_storage_cost")).toHuman());
 
       // Create temporary keys for access key on linkdrop
@@ -117,7 +118,7 @@ if (Workspace.networkIsTestnet()) {
     "Use `claim` to send to existing account without enough gas",
     async (t, { root, tenk }) => {
       const alice = await root.createAccount("alice");
-      let senderKey;
+      await sleep(2000);
       // Create temporary keys for access key on linkdrop
       const [delta, _] = await getDelta(t, tenk, async () => {
         let [linkDelta, senderKey] = await getDelta(t, root, () =>
@@ -165,6 +166,7 @@ if (Workspace.networkIsTestnet()) {
       t.assert(await checkKey(senderKey.getPublicKey(), tenk));
       const tokens = await getTokens(tenk, new_account);
       t.assert(tokens.length == 0, "should contain only one token");
+      await sleep(2000);
 
       // await new_account.delete(root.accountId);
     }

--- a/__test__/linkdrop.ava.ts
+++ b/__test__/linkdrop.ava.ts
@@ -3,6 +3,9 @@ import {
   NearAccount,
   randomAccountId,
 } from "near-willem-workspaces-ava";
+import {
+  ava
+} from "near-willem-workspaces-ava";
 import { NEAR, Gas } from "near-units";
 import { readFile } from "fs/promises";
 import {
@@ -19,192 +22,232 @@ import {
   getDelta,
   create_account_and_claim,
   deploy,
+  linkdropCost,
 } from "./util";
 
 const base_cost = NEAR.parse("1 N");
 const min_cost = NEAR.parse("0.01 N");
 
-const runner = Workspace.init(
-  { initialBalance: NEAR.parse("15 N").toString() },
-  async ({ root }) => {
-    const tenk = await deploy(root, "tenk");
-    if (Workspace.networkIsSandbox()) {
-      const testnet = root.getFullAccount("testnet");
-      await testnet.updateAccount({
-        amount: NEAR.parse("1000 N").toString(),
-        code_hash: "12XoaQ18TQYJhj9SaZR3MGUjcvgkE8rtKn4ZMCnVG8Lq",
-      });
-      await testnet.updateContract(
-        await readFile(`${__dirname}/contracts/testnet.wasm`)
-      );
+if (Workspace.networkIsTestnet()) {
+  const runner = Workspace.init(
+    { initialBalance: NEAR.parse("15 N").toString() },
+    async ({ root }) => {
+      const tenk = await deploy(root, "tenk");
+      if (Workspace.networkIsSandbox()) {
+        const testnet = root.getFullAccount("testnet");
+        await testnet.updateAccount({
+          amount: NEAR.parse("1000 N").toString(),
+          code_hash: "12XoaQ18TQYJhj9SaZR3MGUjcvgkE8rtKn4ZMCnVG8Lq",
+        });
+        await testnet.updateContract(
+          await readFile(`${__dirname}/contracts/testnet.wasm`)
+        );
+      }
+      return { tenk };
     }
-    return { tenk };
-  }
-);
+  );
 
-runner.test(
-  "Use `claim` to send to existing account",
-  async (t, { root, tenk }) => {
-    const alice = await root.createAccount("alice");
+  runner.test(
+    "Use `claim` to send to existing account",
+    async (t, { root, tenk }) => {
+      const alice = await root.createAccount("alice");
+      t.log(NEAR.from(await tenk.view("token_storage_cost")).toHuman());
 
-    // Create temporary keys for access key on linkdrop
-    const [delta, _] = await getDelta(t, tenk, async () => {
-      const senderKey = await createLinkdrop(t, tenk, root);
-      await claim(tenk, alice, senderKey);
-      t.assert(
-        !(await checkKey(senderKey.getPublicKey(), tenk)),
-        "key should not exist"
+      // Create temporary keys for access key on linkdrop
+      const [delta, _] = await getDelta(t, tenk, async () => {
+        const owner_cost = await linkdropCost(tenk, root.accountId);
+        t.log(owner_cost.toHuman());
+        const senderKey = await createLinkdrop(t, tenk, root);
+        await claim(t, tenk, alice, senderKey);
+        t.assert(
+          !(await checkKey(senderKey.getPublicKey(), tenk)),
+          "key should not exist"
+        );
+      });
+      await delta.isGreaterOrEqual(NEAR.from(0));
+      t.log(await delta.toHuman());
+      const tokens = await getTokens(tenk, alice);
+      t.assert(tokens.length == 1, "should contain only one token");
+      t.log(
+        `Balance to contract ${
+          tenk.accountId
+        } after linkdrop is claimed ${await delta.toHuman()}`
       );
-    });
-    await delta.isGreaterOrEqual(NEAR.from(0));
-    const tokens = await getTokens(tenk, alice);
-    t.assert(tokens.length == 1, "should contain only one token");
-    t.log(
-      `Balance to contract ${
-        tenk.accountId
-      } after linkdrop is claimed ${await delta.toHuman()}`
-    );
 
-    // await deployEmpty(tenk);
-  }
-);
+      // await deployEmpty(tenk);
+    }
+  );
 
-runner.test(
-  "Use `claim` to send to existing account without enough gas",
-  async (t, { root, tenk }) => {
-    const alice = await root.createAccount("alice");
-    let senderKey;
-    // Create temporary keys for access key on linkdrop
-    const [delta, _] = await getDelta(t, tenk, async () => {
-      senderKey = await createLinkdrop(t, tenk, root);
-      await claim_raw(tenk, alice, senderKey, Gas.parse("50 Tgas"));
+  runner.test(
+    "Use `claim` to send to existing account with normal account",
+    async (t, { root, tenk }) => {
+      const alice = await root.createAccount("alice");
+      t.log(NEAR.from(await tenk.view("token_storage_cost")).toHuman());
+
+      // Create temporary keys for access key on linkdrop
+      const [delta, _] = await getDelta(t, tenk, async () => {
+        const owner_cost = await linkdropCost(tenk, alice.accountId);
+        t.log(owner_cost.toHuman());
+        const senderKey = await createLinkdrop(t, tenk, alice);
+        await claim(t, tenk, alice, senderKey);
+        t.assert(
+          !(await checkKey(senderKey.getPublicKey(), tenk)),
+          "key should not exist"
+        );
+      });
+      await delta.isGreaterOrEqual(NEAR.from(0));
+      t.log(await delta.toHuman());
+      const tokens = await getTokens(tenk, alice);
+      t.assert(tokens.length == 1, "should contain only one token");
+      t.log(
+        `Balance to contract ${
+          tenk.accountId
+        } after linkdrop is claimed ${await delta.toHuman()}`
+      );
+
+      // await deployEmpty(tenk);
+    }
+  );
+
+  runner.test(
+    "Use `claim` to send to existing account without enough gas",
+    async (t, { root, tenk }) => {
+      const alice = await root.createAccount("alice");
+      let senderKey;
+      // Create temporary keys for access key on linkdrop
+      const [delta, _] = await getDelta(t, tenk, async () => {
+        let [linkDelta, senderKey] = await getDelta(t, root, () =>
+          createLinkdrop(t, tenk, root)
+        );
+        t.log(await linkDelta.toHuman());
+        await claim_raw(tenk, alice, senderKey, Gas.parse("50 Tgas"));
+        t.assert(
+          await checkKey(senderKey.getPublicKey(), tenk),
+          "key should still exist"
+        );
+      });
+      await delta.isGreaterOrEqual(NEAR.from(0));
+
+      const tokens = await getTokens(tenk, alice);
+      t.assert(tokens.length == 0, "should contain not token");
+      t.log(
+        `Balance to contract ${
+          tenk.accountId
+        } after linkdrop is claimed ${await delta.toHuman()}`
+      );
+
+      // await deployEmpty(tenk);
+    }
+  );
+
+  runner.test(
+    "claim_account_and_claim to create an claim account with not enough gas",
+    async (t, { root, tenk }) => {
+      const senderKey = await createLinkdrop(t, tenk, root);
+
+      // Create a random subaccount
+      const new_account_id = `${randomAccountId("d", 10, 10)}.testnet`;
+
+      // Claim account
+      const new_account = await create_account_and_claim(
+        t,
+        tenk,
+        new_account_id,
+        senderKey,
+        Gas.parse("50 Tgas"),
+        false
+      );
+
+      t.assert(await checkKey(senderKey.getPublicKey(), tenk));
+      const tokens = await getTokens(tenk, new_account);
+      t.assert(tokens.length == 0, "should contain only one token");
+
+      // await new_account.delete(root.accountId);
+    }
+  );
+
+  // TODO: there is a race condition on the key store.  Either need multiple keys per account,
+  // runner.test(
+  //   "Use `claim` to send to existing account back-to-back",
+  //   async (t, { root, tenk }) => {
+  //     const contractDelta = await BalanceDelta.create(tenk, t);
+  //     // Create temporary keys for access key on linkdrop
+  //     const senderKey = await createLinkdrop(t, tenk, root);
+  //     t.log("linkdrop cost", await contractDelta.toHuman());
+  //     const alice = await root.createAccount("alice");
+  //     const delta = await BalanceDelta.create(root, t);
+  //     claim_raw(tenk, alice, senderKey);
+  //     claim_raw(tenk, root, senderKey);
+  //     await claim_raw(tenk, alice, senderKey);
+  //     const tokens = await getTokens(tenk, alice);
+  //     t.log(tokens);
+  //     t.is(tokens.length, 1, "should contain at least one token");
+  //     t.assert(
+  //       !(await checkKey(senderKey.getPublicKey(), tenk)),
+  //       "key should not exist"
+  //     );
+  //     await delta.isGreater();
+  //     await contractDelta.isZero();
+  //     // await deployEmpty(tenk);
+  //   }
+  // );
+
+  runner.test(
+    "Use `claim` to send to non-existent account",
+    async (t, { root, tenk }) => {
+      // Create temporary keys for access key on linkdrop
+      const delta = await BalanceDelta.create(tenk, t);
+      const senderKey = await createLinkdrop(t, tenk, root);
+      // Bad account invalid accountid
+      const alice = await root.getFullAccount("alice--");
+      t.log(`Delta ${await delta.toHuman()}`);
+      await claim_raw(tenk, alice, senderKey);
       t.assert(
         await checkKey(senderKey.getPublicKey(), tenk),
         "key should still exist"
       );
-    });
-    await delta.isGreaterOrEqual(NEAR.from(0));
+    }
+  );
 
-    const tokens = await getTokens(tenk, alice);
-    t.assert(tokens.length == 0, "should contain only one token");
-    t.log(
-      `Balance to contract ${
-        tenk.accountId
-      } after linkdrop is claimed ${await delta.toHuman()}`
-    );
+  const GAS_COST_ON_FAILURE = NEAR.parse("570 μN").neg();
 
-    // await deployEmpty(tenk);
-  }
-);
-
-runner.test(
-  "claim_account_and_claim to create an claim account with not enough gas",
-  async (t, { root, tenk }) => {
-    const senderKey = await createLinkdrop(t, tenk, root);
-
-    // Create a random subaccount
-    const new_account_id = `${randomAccountId("d", 10, 10)}.testnet`;
-
-    // Claim account
-    const new_account = await create_account_and_claim(
-      t,
-      tenk,
-      new_account_id,
-      senderKey,
-      Gas.parse("50 Tgas"),
-      false
-    );
-
-    t.assert(await checkKey(senderKey.getPublicKey(), tenk));
-    const tokens = await getTokens(tenk, new_account);
-    t.assert(tokens.length == 0, "should contain only one token");
-
-    // await new_account.delete(root.accountId);
-  }
-);
-
-// TODO: there is a race condition on the key store.  Either need multiple keys per account,
-// runner.test(
-//   "Use `claim` to send to existing account back-to-back",
-//   async (t, { root, tenk }) => {
-//     const contractDelta = await BalanceDelta.create(tenk, t);
-//     // Create temporary keys for access key on linkdrop
-//     const senderKey = await createLinkdrop(t, tenk, root);
-//     t.log("linkdrop cost", await contractDelta.toHuman());
-//     const alice = await root.createAccount("alice");
-//     const delta = await BalanceDelta.create(root, t);
-//     claim_raw(tenk, alice, senderKey);
-//     claim_raw(tenk, root, senderKey);
-//     await claim_raw(tenk, alice, senderKey);
-//     const tokens = await getTokens(tenk, alice);
-//     t.log(tokens);
-//     t.is(tokens.length, 1, "should contain at least one token");
-//     t.assert(
-//       !(await checkKey(senderKey.getPublicKey(), tenk)),
-//       "key should not exist"
-//     );
-//     await delta.isGreater();
-//     await contractDelta.isZero();
-//     // await deployEmpty(tenk);
-//   }
-// );
-
-runner.test(
-  "Use `claim` to send to non-existent account",
-  async (t, { root, tenk }) => {
+  runner.test("Call `claim` with invalid key", async (t, { root, tenk }) => {
     // Create temporary keys for access key on linkdrop
-    const delta = await BalanceDelta.create(tenk, t);
-    const senderKey = await createLinkdrop(t, tenk, root);
+    // const senderKey = await createLinkdrop(t, tenk, root);
     // Bad account invalid accountid
-    const alice = await root.getFullAccount("alice--");
-    t.log(`Delta ${await delta.toHuman()}`);
-    await claim_raw(tenk, alice, senderKey);
-    t.assert(
-      await checkKey(senderKey.getPublicKey(), tenk),
-      "key should still exist"
-    );
-  }
-);
+    // const alice = await root.createAccount("alice");
+    const senderKey = await root.getKey();
+    const res = await paidFailureGas(t, tenk, async () => {
+      try {
+        await claim_raw(tenk, root, senderKey);
+      } catch {}
+    });
 
-const GAS_COST_ON_FAILURE = NEAR.parse("570 μN").neg();
-
-runner.test("Call `claim` with invalid key", async (t, { root, tenk }) => {
-  // Create temporary keys for access key on linkdrop
-  // const senderKey = await createLinkdrop(t, tenk, root);
-  // Bad account invalid accountid
-  // const alice = await root.createAccount("alice");
-  const senderKey = await root.getKey();
-  const res = await paidFailureGas(t, tenk, async () => {
-    try {
-      await claim_raw(tenk, root, senderKey);
-    } catch {}
+    // TODO: add back after fix in api -js is released
+    // t.assert(res.failed, `${root.accountId} claiming from ${tenk.accountId}`);
   });
 
-  // TODO: add back after fix in api -js is released
-  // t.assert(res.failed, `${root.accountId} claiming from ${tenk.accountId}`);
-});
+  // runner.test(
+  //   "Spam `claim` to send to non-existent account",
+  //   async (t, { root, tenk }) => {
+  //     // Create temporary keys for access key on linkdrop
+  //     const senderKey = await createLinkdrop(t, tenk, root);
+  //     // Bad account invalid accountid
+  //     const alice = await root.getFullAccount("alice--");
+  //     const delta = await BalanceDelta.create(tenk, t);
 
-// runner.test(
-//   "Spam `claim` to send to non-existent account",
-//   async (t, { root, tenk }) => {
-//     // Create temporary keys for access key on linkdrop
-//     const senderKey = await createLinkdrop(t, tenk, root);
-//     // Bad account invalid accountid
-//     const alice = await root.getFullAccount("alice--");
-//     const delta = await BalanceDelta.create(tenk, t);
+  //     await repeat(5, () => claim_raw(tenk, alice, senderKey));
+  //     debugger;
+  //     t.log(`Delta ${await delta.toHuman()}`);
+  //     t.assert(
+  //       await checkKey(senderKey.getPublicKey(), tenk),
+  //       "key should still exist"
+  //     );
+  //   }
+  // );
 
-//     await repeat(5, () => claim_raw(tenk, alice, senderKey));
-//     debugger;
-//     t.log(`Delta ${await delta.toHuman()}`);
-//     t.assert(
-//       await checkKey(senderKey.getPublicKey(), tenk),
-//       "key should still exist"
-//     );
-//   }
-// );
+  // TODO figure out why this fails on sandbox
 
-// TODO figure out why this fails on sandbox
-if (Workspace.networkIsTestnet()) {
   runner.test(
     "Use `create_account_and_claim` with existent account",
     async (t, { root, tenk }) => {
@@ -214,7 +257,7 @@ if (Workspace.networkIsTestnet()) {
       // Bad account invalid accountid
       const alice = root;
       const [delta, res] = await getDelta(t, tenk, () =>
-        create_account_and_claim(t, tenk, alice, senderKey)
+        create_account_and_claim(t, tenk, alice.accountId, senderKey)
       );
       await delta.isLessOrEqual(NEAR.parse("1.02 N"));
       const tokens = await getTokens(tenk, root);
@@ -250,15 +293,17 @@ if (Workspace.networkIsTestnet()) {
       const tokens = await getTokens(tenk, new_account);
       t.assert(tokens.length == 1, "should contain only one token");
 
-      await new_account.delete(root.accountId);
+      // await new_account.delete(root.accountId);
     }
   );
+  
+  function paidFailureGas<T>(t, tenk, fn: () => Promise<T>): Promise<T> {
+    return hasDelta<T>(t, tenk, GAS_COST_ON_FAILURE, false, fn);
+  }
+  
+} else {
+  ava("skipped on sandbox", (t) => t.assert(true));
 }
-
-function paidFailureGas<T>(t, tenk, fn: () => Promise<T>): Promise<T> {
-  return hasDelta<T>(t, tenk, GAS_COST_ON_FAILURE, false, fn);
-}
-
 // Only relevant when not using feature "for_sale"
 // runner.test("Owner can create links for free", async (t, { root, tenk }) => {
 //   const tenkDelta = await BalanceDelta.create(tenk, t);

--- a/__test__/royalties.ava.ts
+++ b/__test__/royalties.ava.ts
@@ -1,54 +1,74 @@
 import { Workspace, NearAccount } from "near-willem-workspaces-ava";
 import { NEAR } from "near-units";
-import { deploy, mint } from "./util";
+import { deploy, getDelta, mint, totalCost } from "./util";
 
-function createRoyalties({ root, alice, bob, eve }) {
-  return {
-    accounts: {
-      [root.accountId]: 10,
-      [alice]: 10,
-      [bob]: 10,
-      [eve]: 70,
-    },
-    percent: 20,
-  };
-}
-
-function subaccounts(root: NearAccount): string[] {
-  return ["bob", "alice", "eve"].map((n) => root.makeSubAccount(n));
-}
-
-const runner = Workspace.init(
-  { initialBalance: NEAR.parse("20 N").toString() },
-  async ({ root }) => {
-    const [bob, alice, eve] = subaccounts(root);
-    const royalties = createRoyalties({ root, bob, alice, eve });
-    const tenk = await deploy(root, "tenk", {
-      royalties,
-    });
-    return { tenk };
+if (Workspace.networkIsSandbox()) {
+  function createRoyalties({ root, alice, bob, eve }) {
+    return {
+      accounts: {
+        [root.accountId]: 10,
+        [alice.accountId]: 10,
+        [bob.accountId]: 10,
+        [eve.accountId]: 70,
+      },
+      percent: 20,
+    };
   }
-);
 
-runner.test("Get Payout", async (t, { root, tenk }) => {
-  const balance = NEAR.parse("500 N");
-  const token_id = await mint(tenk, root);
-  const payouts = await tenk.view("nft_payout", {
-    token_id,
-    balance,
-    max_len_payout: 10,
-  });
-  const [bob, alice, eve] = subaccounts(root);
-  let innerPayout = createRoyalties({ root, bob, alice, eve }).accounts;
-  t.log(innerPayout);
-  Object.keys(innerPayout).map(
-    (key) => (innerPayout[key] = NEAR.parse(`${innerPayout[key]}N`).toString())
+  function subaccounts(root: NearAccount): Promise<NearAccount[]> {
+    return Promise.all(
+      ["bob", "alice", "eve"].map((n) => root.createAccount(n))
+    );
+  }
+
+  const runner = Workspace.init(
+    { initialBalance: NEAR.parse("20 N").toString() },
+    async ({ root }) => {
+      const [bob, alice, eve] = await subaccounts(root);
+      const royalties = createRoyalties({ root, bob, alice, eve });
+      const tenk = await deploy(root, "tenk", {
+        royalties,
+        initial_royalties: royalties,
+        base_cost: NEAR.parse("5 N"),
+        min_cost: NEAR.parse("5 N"),
+      });
+      return { tenk, bob, alice, eve };
+    }
   );
-  innerPayout[root.accountId] = balance
-    .mul(NEAR.from(4))
-    .div(NEAR.from(5))
-    .add(NEAR.from(innerPayout[root.accountId]))
-    .toString();
-  const payout = { payout: innerPayout };
-  t.deepEqual(payouts, payout);
-});
+
+  runner.test("Get Payout", async (t, { root, tenk, eve, alice, bob }) => {
+    const balance = NEAR.parse("500 N");
+    const token_id = await mint(tenk, root);
+    const payouts = await tenk.view("nft_payout", {
+      token_id,
+      balance,
+      max_len_payout: 10,
+    });
+    let innerPayout = createRoyalties({ root, bob, alice, eve }).accounts;
+    t.log(innerPayout);
+    Object.keys(innerPayout).map(
+      (key) =>
+        (innerPayout[key] = NEAR.parse(`${innerPayout[key]}N`).toString())
+    );
+    innerPayout[root.accountId] = balance
+      .mul(NEAR.from(4))
+      .div(NEAR.from(5))
+      .add(NEAR.from(innerPayout[root.accountId]))
+      .toString();
+    const payout = { payout: innerPayout };
+    t.deepEqual(payouts, payout);
+  });
+
+  runner.test("Initial Payout", async (t, { root, tenk, eve }) => {
+    let charlie = await root.createAccount("charlie");
+    const cost = await totalCost(tenk, 1);
+    let [delta, token_id] = await getDelta(t, eve, async () =>
+      mint(tenk, charlie, cost)
+    );
+    t.log(
+      cost.toHuman(),
+      await delta.toHuman(),
+      cost.mul(NEAR.from(1)).div(NEAR.from(5)).toHuman()
+    );
+  });
+}

--- a/__test__/util/delta.ts
+++ b/__test__/util/delta.ts
@@ -16,19 +16,19 @@ export class NEARDelta {
     return this.amount.isZero();
   }
 
-  gt(by: NEAR = NEARDelta.ZERO_NEAR): boolean {
+  gt(by = NEARDelta.ZERO_NEAR): boolean {
     return this.amount.gt(by);
   }
 
-  gte(by: NEAR = NEARDelta.ZERO_NEAR): boolean {
+  gte(by = NEARDelta.ZERO_NEAR): boolean {
     return this.amount.gte(by);
   }
 
-  lt(by: NEAR = NEARDelta.ZERO_NEAR): boolean {
+  lt(by = NEARDelta.ZERO_NEAR): boolean {
     return this.amount.lt(by);
   }
 
-  lte(by: NEAR = NEARDelta.ZERO_NEAR): boolean {
+  lte(by = NEARDelta.ZERO_NEAR): boolean {
     return this.amount.lte(by);
   }
 }
@@ -85,6 +85,10 @@ export class BalanceDelta {
 
   async toHuman(): Promise<string> {
     return (await this.delta()).toHuman();
+  }
+
+  async log(): Promise<void> {
+    this.t.log(`${this.account.accountId} has delta ${await this.toHuman()}`);
   }
 }
 

--- a/__test__/util/index.ts
+++ b/__test__/util/index.ts
@@ -336,3 +336,7 @@ export async function mint(
 }
 
 export * from "./delta";
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/contracts/tenk/src/util.rs
+++ b/contracts/tenk/src/util.rs
@@ -1,5 +1,5 @@
 use core::convert::TryInto;
-use near_sdk::{env, PromiseResult};
+use near_sdk::{env, AccountId, Promise, PromiseResult};
 
 pub fn is_promise_success(num_of_promises: Option<u64>) -> bool {
     let count = env::promise_results_count();
@@ -22,4 +22,11 @@ pub fn get_random_number(shift_amount: u32) -> u32 {
     seed.rotate_left(shift_amount as usize % seed_len);
     arr.copy_from_slice(&seed[..4]);
     u32::from_le_bytes(arr).try_into().unwrap()
+}
+
+pub fn refund(account_id: &AccountId, amount: u128) -> Option<Promise> {
+  if amount > 0 {
+    return Some(Promise::new(account_id.clone()).transfer(amount))
+  };
+  None
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "build:mainnet": "yarn build --features mainnet",
     "test": "ava",
     "test:testnet": "NEAR_WORKSPACES_NETWORK=testnet yarn test",
+    "test:linkdrop": "yarn test:testnet '*/link*'",
     "test:unit": "cargo test",
-    "test:ci": "yarn test:unit && yarn test",
+    "test:ci": "yarn test:unit && yarn test && yarn test:linkdrop",
     "lint": "yarn eslint . --ext .ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:testnet": "NEAR_WORKSPACES_NETWORK=testnet yarn test",
     "test:linkdrop": "yarn test:testnet '*/link*'",
     "test:unit": "cargo test",
-    "test:ci": "yarn test:unit && yarn test && yarn test:linkdrop",
+    "test:ci": "yarn test:unit && yarn test",
     "lint": "yarn eslint . --ext .ts"
   },
   "devDependencies": {

--- a/scripts/nft-uploader-launch-tong.ts
+++ b/scripts/nft-uploader-launch-tong.ts
@@ -1,0 +1,55 @@
+import { File, NFTStorage } from "nft.storage";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { API_TOKEN } from "../api_token";
+
+declare interface File {
+  _parts: any[];
+}
+
+function here(s = ""): string {
+  return path.join(__dirname, "..", "assets","Aquarius1111", s);
+}
+
+const id_regex = /^a(?<id>[0-9]+)/;
+
+async function getInfo(file: string): Promise<{ id: string; info: any }> {
+  const id = file.match(id_regex).groups.id;
+  const infoFile =  `a${id}.json`;
+  const info = (await fs.readFile(here(infoFile))).toString();
+  return {
+    id,
+    info
+  };
+}
+
+async function parseFiles(): Promise<typeof File[]> {
+  const directory = await fs.readdir(here());
+  const pics = directory.filter(s => s.endsWith(".png"));
+  const files = await Promise.all(
+    pics.map(async (file) => {
+      const { id, info } = await getInfo(file);
+      let res = [
+        new File([await fs.readFile(here(file))], `${id}.png`),
+        new File([info], `${id}.json`),
+      ];
+      console.log(id, info);
+      return res;
+    })
+  );
+
+  return files.flat();
+}
+
+function makeLink(s: string): string  {
+  return `https://${s}.ipfs.dweb.link`;
+}
+
+async function main() {
+  const initialFiles = await parseFiles();
+  const client = new NFTStorage({ token: API_TOKEN });
+  const CID = await client.storeDirectory(initialFiles);
+  console.log(makeLink(CID));
+}
+
+void main();


### PR DESCRIPTION
This allows an initial royalties for initial token sale.

The API for token costs now require an account to determine the price, which then returns just the storage costs/base linkdrop costs for the owner.

There also seems to be an issue with testing the linkdrop on sandbox as the prices differ so for now the tests are just performed on testnet.